### PR TITLE
Altered overlay text color for safety page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -196,7 +196,14 @@ main { flex: 1; }
   padding: 0 1rem;
   max-width: 48rem;
 }
-.hero h1, .hero h2 { color: var(--white); margin-bottom: 1rem; }
+.hero .safetycontent {
+  position: relative; z-index: 1;
+  text-align: center;
+  color: var(--black);
+  padding: 0 1rem;
+  max-width: 48rem;
+}
+.hero h1, .hero h2 { color: var(--black); margin-bottom: 1rem; }
 .hero h1 { font-size: 2.25rem; }
 .hero h2 { font-size: 2rem; }
 .hero p { font-size: 1.125rem; }

--- a/safety.html
+++ b/safety.html
@@ -13,7 +13,7 @@
     <section class="hero hero-short">
       <img class="hero-bg" src="images/hero.jpg" alt="Forest trail" style="opacity:0.3">
       <div class="overlay overlay-light"></div>
-      <div class="content">
+      <div class="safetycontent">
         <span id="hero-shield" aria-hidden="true" style="display:inline-block;margin-bottom:0.5rem"></span>
         <h1>Safety &amp; Leave No Trace</h1>
         <p>Protecting yourself, others, and the wilderness we all cherish</p>


### PR DESCRIPTION
Altered CSS file to separate safety page header overlay text styling from other pages to allow for changing styling without impacting other pages. Safety page originally had white text against a white overlay making it difficult to read. See old version in image below.

<img width="900" height="317" alt="image" src="https://github.com/user-attachments/assets/9e03cc6f-9969-4205-aa6a-5fe13b50734b" />
